### PR TITLE
Query Mongo Resulting In Single jsonl file on GCP

### DIFF
--- a/etl/combineMultiGCP.js
+++ b/etl/combineMultiGCP.js
@@ -1,0 +1,54 @@
+const path = require("path");
+const fs = require("fs");
+const { Storage, Bucket } = require("@google-cloud/storage");
+const { file } = require("googleapis/build/src/apis/file");
+
+// GCP creds/info
+const projectID = process.env.GCP_PROJECT_ID;
+const storage = new Storage({
+    keyFilename: path.join(__dirname, "../prodCreds.json"),
+    projectId: projectID,
+});
+
+// Access GCP, Combine and Delete chunks to a single file
+const combineMultiGCP = async () => {
+    let previousTransfer;
+
+    try {
+        previousTransfer = JSON.parse(
+            fs.readFileSync("./tmp/previousTransfer.json")
+        );
+    } catch (err) {
+        throw "previousTransfer.json file not found; please run an 'etl/' get first";
+    }
+
+    // loop over all collections with multiple files to use the GCP combine method
+    Object.keys(previousTransfer).reduce(async (previousPromise, nextKey) => {
+        await previousPromise;
+
+        let gcpBucket;
+
+        if (nextKey.includes("caliper")) {
+            gcpBucket = process.env.GCP_CALIPER_BUCKET_NAME;
+        } else if (
+            nextKey.includes("stillwater") ||
+            nextKey.includes("Metrc")
+        ) {
+            gcpBucket = process.env.GCP_STILLWATER_BUCKET_NAME;
+        }
+
+        const bucket = new Bucket(storage, gcpBucket);
+        return bucket.combine(previousTransfer[nextKey], nextKey);
+    }, Promise.resolve());
+
+    // remove temp previousTransfer file
+    fs.unlink("./tmp/previousTransfer.json", (err) => {
+        if (err) {
+            console.log("error deleting file", err);
+        } else {
+            console.log("previousTransfer.json deleted");
+        }
+    });
+};
+
+module.exports = { combineMultiGCP };

--- a/etl/combineMultiGCP.js
+++ b/etl/combineMultiGCP.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const fs = require("fs");
 const { Storage, Bucket } = require("@google-cloud/storage");
-const { file } = require("googleapis/build/src/apis/file");
 
 // GCP creds/info
 const projectID = process.env.GCP_PROJECT_ID;
@@ -9,6 +8,21 @@ const storage = new Storage({
     keyFilename: path.join(__dirname, "../prodCreds.json"),
     projectId: projectID,
 });
+
+const deleteGCPFile = async (fileNameArr, bucket) => {
+    for (fileName of fileNameArr) {
+        try {
+            await bucket.deleteFiles({ prefix: fileName });
+            console.log(`Deleting ${fileName} from GCP`)
+        } catch (err) {
+            console.log(
+                `There was an error deleting the file: ${fileName} from GCP`
+            );
+            throw err;
+        }
+    }
+    return true;
+};
 
 // Access GCP, Combine and Delete chunks to a single file
 const combineMultiGCP = async () => {
@@ -39,6 +53,25 @@ const combineMultiGCP = async () => {
 
         const bucket = new Bucket(storage, gcpBucket);
         return bucket.combine(previousTransfer[nextKey], nextKey);
+    }, Promise.resolve());
+
+    // clean up and delete files stored on GCP after combining
+    Object.keys(previousTransfer).reduce(async (previousPromise, nextKey) => {
+        await previousPromise;
+
+        let gcpBucket;
+
+        if (nextKey.includes("caliper")) {
+            gcpBucket = process.env.GCP_CALIPER_BUCKET_NAME;
+        } else if (
+            nextKey.includes("stillwater") ||
+            nextKey.includes("Metrc")
+        ) {
+            gcpBucket = process.env.GCP_STILLWATER_BUCKET_NAME;
+        }
+
+        const bucket = new Bucket(storage, gcpBucket);
+        return deleteGCPFile(previousTransfer[nextKey], bucket);
     }, Promise.resolve());
 
     // remove temp previousTransfer file

--- a/etl/transformData.js
+++ b/etl/transformData.js
@@ -60,25 +60,25 @@ async function transformData(collectionName, query) {
     // retrieves collection data
     let buildSheet = await retrieveCollection(query, collectionName);
 
-    // if buildSheet has more than 2000 items, create files 2000 items at a time
-    if (buildSheet.length > 2000) {
+    // if buildSheet has more than 5000 items, create files 5000 items at a time
+    if (buildSheet.length > 5000) {
         let start = 0;
-        let end = 2000;
+        let end = 5000;
         let buildSheetArr = [];
 
         while (start < buildSheet.length) {
             const subBuildSheet = buildSheet.slice(start, end);
             buildSheetArr.push(subBuildSheet);
-            start += 2000;
+            start += 5000;
             end =
-                end + 2000 < buildSheet.length ? end + 2000 : buildSheet.length;
+                end + 5000 < buildSheet.length ? end + 5000 : buildSheet.length;
         }
 
         for (let i in buildSheetArr) {
             transformAndCreateFile(buildSheetArr[i], `${collectionName}-${i}`);
         }
-        // if fewer than 2000 items, creates single file
-    } else if (buildSheet.length <= 2000) {
+        // if fewer than 5000 items, creates single file
+    } else if (buildSheet.length <= 5000) {
         transformAndCreateFile(buildSheet, collectionName);
     }
 }

--- a/etl/transformData.js
+++ b/etl/transformData.js
@@ -53,30 +53,32 @@ const transformAndCreateFile = async (arr, collectionName) => {
     }
 };
 
+
+
 // create .jsonl file from retrieved data
 async function transformData(collectionName, query) {
     // retrieves collection data
     let buildSheet = await retrieveCollection(query, collectionName);
 
-    // if buildSheet has more than 5000 items, create files 5000 items at a time
-    if (buildSheet.length > 5000) {
+    // if buildSheet has more than 2000 items, create files 2000 items at a time
+    if (buildSheet.length > 2000) {
         let start = 0;
-        let end = 5000;
+        let end = 2000;
         let buildSheetArr = [];
 
         while (start < buildSheet.length) {
             const subBuildSheet = buildSheet.slice(start, end);
             buildSheetArr.push(subBuildSheet);
-            start += 5000;
+            start += 2000;
             end =
-                end + 5000 < buildSheet.length ? end + 5000 : buildSheet.length;
+                end + 2000 < buildSheet.length ? end + 2000 : buildSheet.length;
         }
 
         for (let i in buildSheetArr) {
             transformAndCreateFile(buildSheetArr[i], `${collectionName}-${i}`);
         }
-        // if fewer than 5000 items, creates single file
-    } else if (buildSheet.length <= 5000) {
+        // if fewer than 2000 items, creates single file
+    } else if (buildSheet.length <= 2000) {
         transformAndCreateFile(buildSheet, collectionName);
     }
 }

--- a/routers/etlRouter.js
+++ b/routers/etlRouter.js
@@ -7,8 +7,8 @@ const { getCollectionNames } = require("../collections/retrievedCollections");
 
 // handles /api/etl get requests
 router.get("/", async (req, res) => {
-    // const collections = collectionsInfo();
-    const collections = await getCollectionNames();
+    const collections = collectionsInfo();
+    // const collections = await getCollectionNames();
 
     try {
         await writeAll(collections);
@@ -25,11 +25,12 @@ router.get("/", async (req, res) => {
     }
 });
 
-router.get("/combine", async (req, res) => {
+// merges chunks and deletes from GCP
+router.delete("/", async (req, res) => {
     try {
         await combineMultiGCP();
         res.status(200).json({
-            message: "ETL Combination successful",
+            message: "ETL Combination and removal of chunks successful",
         });
     } catch (err) {
         console.log("etl combine error", err);

--- a/routers/etlRouter.js
+++ b/routers/etlRouter.js
@@ -1,6 +1,7 @@
 // setup/imports
 const router = require("express").Router();
 const { writeAll } = require("../etl/writeToGCP");
+const { combineMultiGCP } = require("../etl/combineMultiGCP");
 const { collectionsInfo } = require("../collections/collectionsInfo");
 const { getCollectionNames } = require("../collections/retrievedCollections");
 
@@ -11,6 +12,7 @@ router.get("/", async (req, res) => {
 
     try {
         await writeAll(collections);
+
         res.status(200).json({
             message: "ETL successful",
         });
@@ -18,6 +20,21 @@ router.get("/", async (req, res) => {
         console.log("etl get error", err);
         res.status(500).json({
             message: "There was an error with ETL",
+            error: err,
+        });
+    }
+});
+
+router.get("/combine", async (req, res) => {
+    try {
+        await combineMultiGCP();
+        res.status(200).json({
+            message: "ETL Combination successful",
+        });
+    } catch (err) {
+        console.log("etl combine error", err);
+        res.status(500).json({
+            message: "There was an error with combining ETL",
             error: err,
         });
     }


### PR DESCRIPTION
Problem: 
- Uploading large files to GCP causing errors. The previous solution implemented chunking to send network requests in smaller sizes.

Approach:
- Played around with the code quite a bit and after some research, it seems the upload size of the files are part of the problem even though GCP can store larger files (may not be fully correct, but that's what the initial research uncovered)

Solution:
- [x] Create a temp JSON file to keep track of larger files that are chunked and uploaded to GCP
- [x] Once query, data transformation, and upload are complete, user can run a DELETE request on the same endpoint
- [x] Delete request will read the temp JSON file, query GCP, merge all chunked files into a single new file, and delete the smaller chunked files.
- [x] Delete temp JSON file on success

Todo:
- [ ] Still working to implement the new code into the initial GET request, but am currently having issues with the delete running before the uploads are complete which is breaking the flow of data