### PR TITLE
Encapsulate Complete Functionality Within GET "/api/etl/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 # credentials
 prodCreds.json
+
+# tmp files
+/tmp/*

--- a/etl/combineMultiGCP.js
+++ b/etl/combineMultiGCP.js
@@ -13,7 +13,7 @@ const deleteGCPFile = async (fileNameArr, bucket) => {
     for (fileName of fileNameArr) {
         try {
             await bucket.deleteFiles({ prefix: fileName });
-            console.log(`Deleting ${fileName} from GCP`)
+            console.log(`Deleting ${fileName} from GCP`);
         } catch (err) {
             console.log(
                 `There was an error deleting the file: ${fileName} from GCP`
@@ -38,7 +38,9 @@ const combineMultiGCP = async () => {
 
     // loop over all collections with multiple files to use the GCP combine method
     Object.keys(previousTransfer).reduce(async (previousPromise, nextKey) => {
-        await previousPromise;
+        await previousPromise.catch((err) => {
+            throw err;
+        });
 
         let gcpBucket;
 
@@ -52,12 +54,18 @@ const combineMultiGCP = async () => {
         }
 
         const bucket = new Bucket(storage, gcpBucket);
-        return bucket.combine(previousTransfer[nextKey], nextKey);
+        return bucket
+            .combine(previousTransfer[nextKey], nextKey)
+            .catch((err) => {
+                throw err;
+            });
     }, Promise.resolve());
 
     // clean up and delete files stored on GCP after combining
     Object.keys(previousTransfer).reduce(async (previousPromise, nextKey) => {
-        await previousPromise;
+        await previousPromise.catch((err) => {
+            throw err;
+        });
 
         let gcpBucket;
 
@@ -71,7 +79,9 @@ const combineMultiGCP = async () => {
         }
 
         const bucket = new Bucket(storage, gcpBucket);
-        return deleteGCPFile(previousTransfer[nextKey], bucket);
+        return deleteGCPFile(previousTransfer[nextKey], bucket).catch((err) => {
+            throw err;
+        });
     }, Promise.resolve());
 
     // remove temp previousTransfer file

--- a/etl/writeToGCP.js
+++ b/etl/writeToGCP.js
@@ -54,7 +54,7 @@ const writeAll = async (collections) => {
         "./tmp/previousTransfer.json",
         JSON.stringify(multiFileCollections)
     );
-    fs.writeFileSync("./tmp/uploadQty.json", JSON.stringify(toCombine));
+    // fs.writeFileSync("./tmp/uploadQty.json", JSON.stringify(toCombine));
 
     fileNames.forEach(async (file) => {
         // gcp buckte name for caliper or stillwater
@@ -94,6 +94,7 @@ const writeAll = async (collections) => {
                 });
             });
     });
+    return toCombine;
 };
 
 module.exports = { writeAll };

--- a/etl/writeToGCP.js
+++ b/etl/writeToGCP.js
@@ -22,6 +22,8 @@ const writeAll = async (collections) => {
 
     // store collections that are uploaded in chunks
     const multiFileCollections = {};
+    // track how many files need to be combined
+    let toCombine = 0;
 
     // create array of files in tmp/
     const fileNames = fs.readdirSync("./tmp/").filter((file) => {
@@ -38,6 +40,8 @@ const writeAll = async (collections) => {
                     // initializing key value pair if not on obj
                     multiFileCollections[colName] = [file];
                 }
+
+                toCombine += 1;
             }
         }
 
@@ -86,6 +90,8 @@ const writeAll = async (collections) => {
                 });
             });
     });
+
+    return toCombine;
 };
 
 module.exports = { writeAll };

--- a/etl/writeToGCP.js
+++ b/etl/writeToGCP.js
@@ -54,6 +54,7 @@ const writeAll = async (collections) => {
         "./tmp/previousTransfer.json",
         JSON.stringify(multiFileCollections)
     );
+    fs.writeFileSync("./tmp/uploadQty.json", JSON.stringify(toCombine));
 
     fileNames.forEach(async (file) => {
         // gcp buckte name for caliper or stillwater
@@ -69,6 +70,7 @@ const writeAll = async (collections) => {
         // const file = bucketName.file(`${collectionName}-${Date.now()}.jsonl`);
         const gcpFile = bucketName.file(file);
         const metadata = {
+            resumable: false,
             metadata: { contentType: "application/octet-stream" },
         };
 
@@ -77,6 +79,7 @@ const writeAll = async (collections) => {
             .pipe(gcpFile.createWriteStream(metadata))
             .on("error", (err) => {
                 console.log("GCP upload error", err);
+                throw "GCP upload error";
             })
             .on("finish", () => {
                 console.log(`${file} file uploaded`);
@@ -84,14 +87,13 @@ const writeAll = async (collections) => {
                 fs.unlink(`./tmp/${file}`, (err) => {
                     if (err) {
                         console.log("error deleting file", err);
+                        throw "Error deleting file";
                     } else {
                         console.log(`${file} file deleted`);
                     }
                 });
             });
     });
-
-    return toCombine;
 };
 
 module.exports = { writeAll };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@google-cloud/common": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
-      "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.6.0.tgz",
+      "integrity": "sha512-aHIFTqJZmeTNO9md8XxV+ywuvXF3xBm5WNmgWeeCK+XN5X+kGW0WEX94wGwj+/MdOnrVf4dL2RvSIt9J5yJG6Q==",
       "requires": {
         "@google-cloud/projectify": "^2.0.0",
         "@google-cloud/promisify": "^2.0.0",
@@ -15,7 +15,7 @@
         "duplexify": "^4.1.1",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "google-auth-library": "^6.1.1",
+        "google-auth-library": "^7.0.2",
         "retry-request": "^4.1.1",
         "teeny-request": "^7.0.0"
       }
@@ -40,11 +40,11 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/storage": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.7.3.tgz",
-      "integrity": "sha512-1or09kfx8bmSMG5MvTCiuooCfS0btDtchvwQpIx/iF2IogzmFhLFFtmCeEpstTsfql6bHAnvN8Up7W5+9kMgdA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.3.tgz",
+      "integrity": "sha512-g++NTmpmwbZZEnBhJi3y1D3YyZ2Y+1xL5blp96eeJhffginMym5tRw/AGNZblDI35U2K1FTJEYqIZ31tbEzs8w==",
       "requires": {
-        "@google-cloud/common": "^3.5.0",
+        "@google-cloud/common": "^3.6.0",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
@@ -54,7 +54,7 @@
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "gcs-resumable-upload": "^3.1.0",
+        "gcs-resumable-upload": "^3.1.3",
         "get-stream": "^6.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
@@ -68,9 +68,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
         }
       }
     },
@@ -154,6 +154,30 @@
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "body-parser": {
@@ -174,9 +198,9 @@
       }
     },
     "bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -297,18 +321,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "ecdsa-sig-formatter": {
@@ -434,9 +446,9 @@
       "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
     "gaxios": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-      "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -455,15 +467,15 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.2.tgz",
-      "integrity": "sha512-VKWP3Xju1JmNX3N4ossnGp3DfIRZjOsMj8sDGPBGnvn8YSruCOVGQBvELfStfIFPybScv/e5sEdWx/qzfnS3+w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.3.tgz",
+      "integrity": "sha512-LjVrv6YVH0XqBr/iBW0JgRA1ndxhK6zfEFFJR4im51QVTj/4sInOXimY2evDZuSZ75D3bHxTaQAdXRukMc1y+w==",
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "google-auth-library": "^6.0.0",
+        "google-auth-library": "^7.0.0",
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
       }
@@ -474,9 +486,9 @@
       "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg=="
     },
     "google-auth-library": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.4.tgz",
-      "integrity": "sha512-q0kYtGWnDd9XquwiQGAZeI2Jnglk7NDi0cChE4tWp6Kpo/kbqnt9scJb0HP+/xqt03Beqw/xQah1OPrci+pOxw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.4.tgz",
+      "integrity": "sha512-o8irYyeijEiecTXeoEe8UKNEzV1X+uhR4b2oNdapDMZixypp0J+eHimGOyx5Joa3UAeokGngdtDLXtq9vDqG2Q==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -498,48 +510,40 @@
       }
     },
     "googleapis": {
-      "version": "67.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-67.0.0.tgz",
-      "integrity": "sha512-luhulHrk42DruR+c12W2sY2rrEVoKVdjaZDuHWSxcp1qz+VxvWQpuiK2QDLCXmo36/VFPMaa+Y7rRUR+Qqzd7w==",
+      "version": "71.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-71.0.0.tgz",
+      "integrity": "sha512-pi3aWckvsEJbZmJ/+MeO8eIWOK2wmSKRRLvCQbgqTLrFce/jEHLusPly+H3FkpmbO3oTtYRUMJJ07Y4F3DeOgA==",
       "requires": {
-        "google-auth-library": "^6.0.0",
-        "googleapis-common": "^4.4.1"
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.2"
       }
     },
     "googleapis-common": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.3.tgz",
-      "integrity": "sha512-W46WKCk3QtlCCfmZyQIH5zxmDOyeV5Qj+qs7nr2ox08eRkEJMWp6iwv542R/PsokXaGUSrmif4vCC4+rGzRSsQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.0.2.tgz",
+      "integrity": "sha512-TL7qronKNZwE/XBvqshwzCPmZGq2gz/beXzANF7EVoO7FsQjOd7dk40DYrXkoCpvbnJHCQKWESq6NansiIPFqA==",
       "requires": {
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "google-auth-library": "^6.0.0",
+        "google-auth-library": "^7.0.2",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
         "uuid": "^8.0.0"
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "gtoken": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
-      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
-        }
+        "jws": "^4.0.0"
       }
     },
     "hash-stream-validation": {
@@ -660,9 +664,9 @@
       }
     },
     "json2csv": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.5.tgz",
-      "integrity": "sha512-/UyvnfuUghRM+C/AiQ02X0LS+/AKfugcwaWo/gAz1pi203v29sUMrMSNEC088i+h0EG39eSsmeL9Z0iK+9MM0A==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.6.tgz",
+      "integrity": "sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==",
       "requires": {
         "commander": "^6.1.0",
         "jsonparse": "^1.3.1",
@@ -712,13 +716,6 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
         "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
       }
     },
     "media-typer": {
@@ -766,14 +763,14 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mongodb": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
+      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
+        "optional-require": "^1.0.2",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
@@ -821,6 +818,11 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "optional-require": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.2.tgz",
+      "integrity": "sha512-HZubVd6IfHsbnpdNF/ICaSAzBUEW1TievpkjY3tB4Jnk8L7+pJ3conPzUt3Mn/6OZx9uzTDOHYPGA8/AxYHBOg=="
     },
     "p-limit": {
       "version": "3.1.0",
@@ -895,32 +897,14 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
-    },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "retry": {
       "version": "0.12.0",
@@ -970,9 +954,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "send": {
       "version": "0.17.1",
@@ -1055,11 +1039,18 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "stubs": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@google-cloud/storage": "^5.7.3",
+        "@google-cloud/storage": "^5.8.3",
         "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "fs": "0.0.1-security",
-        "googleapis": "^67.0.0",
-        "json2csv": "^5.0.5",
-        "mongodb": "^3.6.3"
+        "googleapis": "^71.0.0",
+        "json2csv": "^5.0.6",
+        "mongodb": "^3.6.6"
     }
 }

--- a/routers/etlRouter.js
+++ b/routers/etlRouter.js
@@ -27,33 +27,33 @@ router.get("/", async (req, res) => {
                 return file.includes(".jsonl");
             });
 
-            try {
-                const extraWait =
-                    jsonlFiles.length == 0 ? 0 : jsonlFiles.length * 10000;
+            const extraWait =
+                jsonlFiles.length == 0 ? 0 : jsonlFiles.length * 10000;
 
-                console.log(
-                    `... ... Waiting for an extra ${extraWait} ms for uploads to complete... ...`
-                );
-                setTimeout(async () => {
-                    // merges chunks and deletes from GCP
+            console.log(
+                `... ... Waiting for an extra ${extraWait} ms for uploads to complete... ...`
+            );
+            setTimeout(async () => {
+                // merges chunks and deletes from GCP
+                try {
                     await combineMultiGCP(
                         previousTransfer.multiFileCollections
                     );
-                }, extraWait);
-
-                setTimeout(() => {
-                    res.status(200).json({
-                        msg: "ETL Successful",
+                } catch (err) {
+                    console.log("etl combine error", err);
+                    res.status(500).json({
+                        message: "There was an error with combining ETL",
+                        error: err,
                     });
-                }, previousTransfer.qty * 200 + 1200);
-                
-            } catch (err) {
-                console.log("etl combine error", err);
-                res.status(500).json({
-                    message: "There was an error with combining ETL",
-                    error: err,
+                }
+            }, extraWait);
+
+            setTimeout(() => {
+                res.status(200).json({
+                    msg: "ETL Successful",
                 });
-            }
+            }, previousTransfer.qty * 200 + 1000);
+
             // set a 2000ms default delay
         }, previousTransfer.qty * 28000 + 2000);
     } catch (err) {

--- a/routers/etlRouter.js
+++ b/routers/etlRouter.js
@@ -4,6 +4,7 @@ const { writeAll } = require("../etl/writeToGCP");
 const { combineMultiGCP } = require("../etl/combineMultiGCP");
 const { collectionsInfo } = require("../collections/collectionsInfo");
 const { getCollectionNames } = require("../collections/retrievedCollections");
+const fs = require("fs");
 
 // handles /api/etl get requests
 router.get("/", async (req, res) => {
@@ -13,9 +14,37 @@ router.get("/", async (req, res) => {
     try {
         await writeAll(collections);
 
-        res.status(200).json({
-            message: "ETL successful",
+        const qty = JSON.parse(fs.readFileSync("./tmp/uploadQty.json"));
+        fs.unlink("./tmp/uploadQty.json", (err) => {
+            if (err) {
+                console.log("error deleting file", err);
+            } else {
+                console.log("uploadQty.json deleted");
+            }
         });
+
+        console.log(
+            `Waiting ${qty * 28 + 2} seconds for uploads to complete... ...`
+        );
+        setTimeout(async () => {
+            console.log("STARTING: COMBINING");
+
+            try {
+                await combineMultiGCP();
+
+                setTimeout(() => {
+                    res.status(200).json({
+                        msg: "ETL Successful",
+                    });
+                }, 1200);
+            } catch (err) {
+                console.log("etl combine error", err);
+                res.status(500).json({
+                    message: "There was an error with combining ETL",
+                    error: err,
+                });
+            }
+        }, qty * 28000 + 2000);
     } catch (err) {
         console.log("etl get error", err);
         res.status(500).json({


### PR DESCRIPTION
Changes:
- [x] GET "/api/etl/" now queries Mongo, Writes to /temp/*.jsonl, Uploads to GCP, clears out temp folder, and chunked files are combined & deleted in GCP buckets.
- [x] Remove the need to use previousTransfer.json
- [x] Throw errors throughout each function and callback to respond with 500 errors back when something fails (rather than simply logging the error to the console)
- [x] Track how many chunked files will be uploaded & wait for 30 seconds per file uploaded

Possible Bugs:
- [ ] Need to test if sleep timer is long enough in production
- [ ] Error reported that sometimes uploaded files are 0 B in size